### PR TITLE
use stream_chunk instead of get_block

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import anvil
 from multiprocessing import Pool
@@ -6,17 +7,14 @@ from collections import Counter
 def count_blocks(region_file):
     block_counts = Counter()
     region = anvil.Region.from_file(region_file)
-    
+
     for x in range(32):
         for z in range(32):
             try:
                 chunk = anvil.Chunk.from_region(region, x, z)
-                for y in range(-64, 321):
-                    for dx in range(16):
-                        for dz in range(16):
-                            block = chunk.get_block(dx, y, dz)
-                            if block.id != 'minecraft:air':
-                                block_counts[block.id] += 1
+                for block in anvil.Chunk.stream_chunk(chunk):
+                    if block.id != 'minecraft:air':
+                        block_counts[block.id] += 1
             except:
                 pass
     return block_counts
@@ -24,12 +22,15 @@ def count_blocks(region_file):
 def main():
     filenames = os.listdir("region_testdata/")
     print(filenames)
-    with Pool(processes=11) as pool:
+    with Pool(processes=20) as pool:
         results = pool.map(count_blocks, ['region_testdata/' + filename for filename in filenames])
         total_counts = Counter()
-        for result in results:
-            total_counts += result
-        print(f"Block counts in the region: {dict(total_counts)}")
+    for result in results:
+        total_counts += result
+
+    print(f"Block counts in the region: {dict(total_counts)}")
+    with open("out.json", "w+") as f:
+        json.dump(dict(total_counts), f)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Increases performance by 4.5x.

With the old version, a world sample took 3709 seconds, while the new version only took 812 seconds.